### PR TITLE
remove `let-env`

### DIFF
--- a/.chezmoitemplates/config.nu
+++ b/.chezmoitemplates/config.nu
@@ -183,7 +183,7 @@ let light_theme = {
 
 
 # The default config record. This is where much of your global configuration is setup.
-let-env config = {
+$env.config = {
   # true or false to enable or disable the welcome banner at startup
   show_banner: true
   ls: {
@@ -268,7 +268,6 @@ let-env config = {
     max_size: 10000 # Session has to be reloaded for this to take effect
     sync_on_enter: true # Enable to share history between multiple sessions, else you have to close the session to write history to file
     file_format: "plaintext" # "sqlite" or "plaintext"
-    history_isolation: true # true enables history isolation, false disables it. true will allow the history to be isolated to the current session. false will allow the history to be shared across all sessions.
   }
   completions: {
     case_sensitive: false # set to true to enable case-sensitive completions
@@ -543,20 +542,20 @@ let-env config = {
   ]
 }
 
-let-env STARSHIP_SHELL = "nu"
+$env.STARSHIP_SHELL = "nu"
 
 def create_left_prompt [] {
     starship prompt --cmd-duration $env.CMD_DURATION_MS $'--status=($env.LAST_EXIT_CODE)'
 }
 
 # Use nushell functions to define your right and left prompt
-let-env PROMPT_COMMAND = { || create_left_prompt }
-let-env PROMPT_COMMAND_RIGHT = ""
+$env.PROMPT_COMMAND = { || create_left_prompt }
+$env.PROMPT_COMMAND_RIGHT = ""
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = ""
-let-env PROMPT_INDICATOR_VI_INSERT = ": "
-let-env PROMPT_INDICATOR_VI_NORMAL = "〉"
-let-env PROMPT_MULTILINE_INDICATOR = "::: "
+$env.PROMPT_INDICATOR = ""
+$env.PROMPT_INDICATOR_VI_INSERT = ": "
+$env.PROMPT_INDICATOR_VI_NORMAL = "〉"
+$env.PROMPT_MULTILINE_INDICATOR = "::: "
 

--- a/.chezmoitemplates/env.nu
+++ b/.chezmoitemplates/env.nu
@@ -44,21 +44,21 @@ def create_right_prompt [] {
 }
 
 # Use nushell functions to define your right and left prompt
-let-env PROMPT_COMMAND = {|| create_left_prompt }
-let-env PROMPT_COMMAND_RIGHT = {|| create_right_prompt }
+$env.PROMPT_COMMAND = {|| create_left_prompt }
+$env.PROMPT_COMMAND_RIGHT = {|| create_right_prompt }
 
 # The prompt indicators are environmental variables that represent
 # the state of the prompt
-let-env PROMPT_INDICATOR = {|| "> " }
-let-env PROMPT_INDICATOR_VI_INSERT = {|| ": " }
-let-env PROMPT_INDICATOR_VI_NORMAL = {|| "> " }
-let-env PROMPT_MULTILINE_INDICATOR = {|| "::: " }
+$env.PROMPT_INDICATOR = {|| "> " }
+$env.PROMPT_INDICATOR_VI_INSERT = {|| ": " }
+$env.PROMPT_INDICATOR_VI_NORMAL = {|| "> " }
+$env.PROMPT_MULTILINE_INDICATOR = {|| "::: " }
 
 # Specifies how environment variables are:
 # - converted from a string to a value on Nushell startup (from_string)
 # - converted from a value back to a string when running external commands (to_string)
 # Note: The conversions happen *after* config.nu is loaded
-let-env ENV_CONVERSIONS = {
+$env.ENV_CONVERSIONS = {
   "PATH": {
     from_string: { |s| $s | split row (char esep) | path expand --no-symlink }
     to_string: { |v| $v | path expand --no-symlink | str join (char esep) }
@@ -72,21 +72,21 @@ let-env ENV_CONVERSIONS = {
 # Directories to search for scripts when calling source or use
 #
 # By default, <nushell-config-dir>/scripts is added
-let-env NU_LIB_DIRS = [
+$env.NU_LIB_DIRS = [
     ($nu.default-config-dir | path join 'scripts')
 ]
 
 # Directories to search for plugin binaries when calling register
 #
 # By default, <nushell-config-dir>/plugins is added
-let-env NU_PLUGIN_DIRS = [
+$env.NU_PLUGIN_DIRS = [
     ($nu.default-config-dir | path join 'plugins')
 ]
 
 # To add entries to PATH (on Windows you might use Path), you can use the following pattern:
 # let-env PATH = ($env.PATH | split row (char esep) | prepend '/some/path')
 
-let-env PATH = ($env.PATH | split row (char esep) | prepend ($env.HOME | path join ".cargo/bin"))
-let-env PATH = ($env.PATH | split row (char esep) | prepend ($env.HOME | path join ".local/bin"))
-let-env PATH = ($env.PATH | split row (char esep) | prepend ($env.HOME | path join ".asdf/bin"))
+$env.PATH = ($env.PATH | split row (char esep) | prepend ($env.HOME | path join ".cargo/bin"))
+$env.PATH = ($env.PATH | split row (char esep) | prepend ($env.HOME | path join ".local/bin"))
+$env.PATH = ($env.PATH | split row (char esep) | prepend ($env.HOME | path join ".asdf/bin"))
 

--- a/Library/Application Support/nushell/config.nu.tmpl
+++ b/Library/Application Support/nushell/config.nu.tmpl
@@ -1,4 +1,4 @@
 {{- template "config.nu" . -}}
 
-let-env ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')
+$env.ASDF_NU_DIR = (brew --prefix asdf | str trim | into string | path join 'libexec')
 source /opt/homebrew/opt/asdf/libexec/asdf.nu

--- a/Library/Application Support/nushell/env.nu.tmpl
+++ b/Library/Application Support/nushell/env.nu.tmpl
@@ -1,4 +1,5 @@
 {{- template "env.nu" . -}}
 
-let-env PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin')
-let-env ASDF_NU_DIR = (brew --prefix asdf | into string | str trim | path join 'libexec')
+$env.PATH = ($env.PATH | split row (char esep) | prepend '/opt/homebrew/bin')
+$env.ASDF_NU_DIR = (brew --prefix asdf | into string | str trim | path join 'libexec')
+$env.LC_ALL = "en_US.UTF-8"


### PR DESCRIPTION
`let-env` was deprecated in the latest version of nushell. this just updates the nushell configs to use the `$env.VAR` syntax instead