### PR TITLE
use the new rainbow-delimiters fork

### DIFF
--- a/dot_config/nvim/lua/plugins.lua
+++ b/dot_config/nvim/lua/plugins.lua
@@ -79,16 +79,32 @@ local plugins = {
 		dependencies = { "nvim-tree/nvim-web-devicons" },
 	},
 	{
-		"HiPhish/nvim-ts-rainbow2",
+		url = "https://gitlab.com/HiPhish/rainbow-delimiters.nvim.git",
 		dependencies = {
 			"nvim-treesitter/nvim-treesitter",
 		},
 		config = function()
-			require("nvim-treesitter.configs").setup({
-				rainbow = {
-					enable = true,
-					query = "rainbow-parens",
-					strategy = require("ts-rainbow").strategy.global,
+			require("rainbow-delimiters.setup").setup({
+				strategy = {
+						[''] = rainbow_delimiters.strategy['global'],
+						vim = rainbow_delimiters.strategy['local'],
+				},
+				query = {
+						[''] = 'rainbow-delimiters',
+						lua = 'rainbow-blocks',
+				},
+				priority = {
+						[''] = 110,
+						lua = 210,
+				},
+				highlight = {
+						'RainbowDelimiterRed',
+						'RainbowDelimiterYellow',
+						'RainbowDelimiterBlue',
+						'RainbowDelimiterOrange',
+						'RainbowDelimiterGreen',
+						'RainbowDelimiterViolet',
+						'RainbowDelimiterCyan',
 				},
 			})
 		end,


### PR DESCRIPTION
migrated to the new fork for rainbow delimiters while doing some Typescript work: https://gitlab.com/HiPhish/rainbow-delimiters.nvim

from the [old repository](https://github.com/HiPhish/nvim-ts-rainbow2):

> Warning

> This plugin is deprecated! Please use [rainbow-delimiters.nvim](https://gitlab.com/HiPhish/rainbow-delimiters.nvim) instead ([GitHub mirror](https://github.com/hiphish/rainbow-delimiters.nvim)). This plugin is implemented as a module for [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter), but nvim-treesitter has deprecated the module feature. Hence why I have created a new standalone plugin which does not depend on nvim-treesitter.