### PR TITLE
wezterm and zellij config tweaks

### DIFF
--- a/dot_config/nvim/lua/rust.lua
+++ b/dot_config/nvim/lua/rust.lua
@@ -18,7 +18,7 @@ rust = {
 			vim.o.updatetime = 250
 
 			vim.api.nvim_create_autocmd("CursorHold", {
-				buffer = bufnr,
+				buffer = buf_num,
 				callback = function()
 					local opts = {
 						focusable = false,
@@ -35,7 +35,7 @@ rust = {
 
 		local capabilities = require('cmp_nvim_lsp').default_capabilities(vim.lsp.protocol.make_client_capabilities())
 
-		rt = require('rust-tools')
+		local rt = require('rust-tools')
 
 		rt.setup({
 			server = {

--- a/dot_config/wezterm/wezterm.lua
+++ b/dot_config/wezterm/wezterm.lua
@@ -1,17 +1,19 @@
 local wezterm = require("wezterm")
 
 local config = {
--- https://wezfurlong.org/wezterm/colorschemes/index.html
---		color_scheme = "Andromeda",
---	color_scheme = 'GitHub Dark',
-	color_scheme = 'Tokyo Night',
-	font = wezterm.font('Fira Code'),
+	-- https://wezfurlong.org/wezterm/colorschemes/index.html
+	--		color_scheme = "Andromeda",
+	--	color_scheme = 'GitHub Dark',
+	color_scheme = "Tokyo Night",
+	font = wezterm.font("Fira Code"),
 	colors = {
 		visual_bell = "#777777",
 	},
+	use_fancy_tab_bar = false,
+	hide_tab_bar_if_only_one_tab = true,
 	window_frame = {
+		font_size = 13.0,
 		active_titlebar_bg = "#020202",
-		font_size = 11.0,
 		inactive_titlebar_bg = "#555555",
 	},
 	visual_bell = {

--- a/dot_config/zellij/config.kdl
+++ b/dot_config/zellij/config.kdl
@@ -1,8 +1,10 @@
 // If you'd like to override the default keybindings completely, be sure to change "keybinds" to "keybinds clear-defaults=true"
 keybinds {
+		unbind "Ctrl o"
     normal {
         // uncomment this and adjust key if using copy_on_select=false
         // bind "Alt c" { Copy; }
+				bind "Ctrl a" { SwitchToMode "Session"; }
     }
     locked {
         bind "Ctrl g" { SwitchToMode "Normal"; }


### PR DESCRIPTION
some tweaks to the wezterm tab bar config

change session hotkey for zellij to `Ctrl+a` to make it more compatible with (neo)vim